### PR TITLE
refactor: convert player/projectile to mixins

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,6 +12,34 @@ void main() {
   runApp(GameWidget(game: ArenaGame()));
 }
 
+/// Custom player with sprite-friendly rendering.
+class ArenaPlayer extends CircleComponent with AsobiPlayer {
+  ArenaPlayer({required Vector2 size})
+      : super(radius: size.x / 2, anchor: Anchor.center, priority: 5);
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    paint.color = isDead
+        ? const Color(0xFF888888)
+        : isLocal
+            ? const Color(0xFF00FFFF)
+            : const Color(0xFFFF4444);
+  }
+}
+
+/// Custom projectile.
+class ArenaBullet extends CircleComponent with AsobiProjectile {
+  ArenaBullet()
+      : super(radius: 0.15, anchor: Anchor.center, priority: 3);
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    paint.color = isLocal ? const Color(0xFFFFFF00) : const Color(0xFFFFFFFF);
+  }
+}
+
 class ArenaGame extends FlameGame
     with HasAsobi, KeyboardEvents, MouseMovementDetector, TapCallbacks {
   late final AsobiInputSender _input;
@@ -19,39 +47,34 @@ class ArenaGame extends FlameGame
 
   @override
   Future<void> onLoad() async {
-    // 1. Connect to backend
     await asobiConnect('localhost', port: 8084);
     await asobi.auth.register('player_${DateTime.now().millisecond}', 'pass');
     await asobi.realtime.connect();
 
-    // 2. Find a match
     asobi.realtime.onMatchmakerMatched.stream.listen((_) => _startGame());
     await asobi.realtime.addToMatchmaker(mode: 'arena');
   }
 
   void _startGame() {
-    // 3. Add network sync — handles all entity lifecycle
     _sync = AsobiNetworkSync(
       client: asobi,
       pixelsPerUnit: 50,
-      onStateUpdate: (_) {
-        // Access local player stats via _sync.localPlayer
-      },
+      playerBuilder: (id, isLocal) =>
+          ArenaPlayer(size: Vector2.all(0.64))..initPlayer(id: id, local: isLocal),
+      projectileBuilder: (id, owner, isLocal) =>
+          ArenaBullet()..initProjectile(id: id, ownerId: owner, local: isLocal),
       onMatchFinished: (result) {
         // Handle game over
       },
     );
     world.add(_sync);
 
-    // 4. Add input sender — captures WASD + mouse
     _input = AsobiInputSender(client: asobi, pixelsPerUnit: 50);
     world.add(_input);
 
-    // 5. Setup camera
-    camera.viewfinder.position = Vector2(8, 6); // center of 800x600 / 50
+    camera.viewfinder.position = Vector2(8, 6);
     camera.viewfinder.zoom = size.y / 13;
 
-    // 6. Arena bounds
     world.add(RectangleComponent(
       size: Vector2(16, 12),
       paint: Paint()

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,0 +1,14 @@
+name: flame_asobi_example
+description: Example multiplayer arena game using flame_asobi.
+publish_to: none
+
+environment:
+  sdk: ">=3.4.0 <4.0.0"
+  flutter: ">=3.22.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flame: ">=1.18.0 <2.0.0"
+  flame_asobi:
+    path: ../

--- a/lib/src/asobi_network_sync.dart
+++ b/lib/src/asobi_network_sync.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:ui';
 import 'package:asobi/asobi.dart';
 import 'package:flame/components.dart';
 
@@ -7,21 +6,31 @@ import 'asobi_player.dart';
 import 'asobi_projectile.dart';
 
 /// Callback for building a player component from server data.
-typedef PlayerBuilder = AsobiPlayer Function(String playerId, bool isLocal);
+///
+/// Must return a [PositionComponent] with the [AsobiPlayer] mixin applied.
+typedef PlayerBuilder = PositionComponent Function(String playerId, bool isLocal);
 
 /// Callback for building a projectile component from server data.
-typedef ProjectileBuilder = AsobiProjectile Function(int id, String owner, bool isLocal);
+///
+/// Must return a [PositionComponent] with the [AsobiProjectile] mixin applied.
+typedef ProjectileBuilder = PositionComponent Function(int id, String owner, bool isLocal);
 
 /// Synchronizes server match state with Flame components.
 ///
-/// Automatically creates, updates, and removes [AsobiPlayer] and
-/// [AsobiProjectile] children based on the match state received
-/// from the server via WebSocket.
+/// Automatically creates, updates, and removes player and projectile
+/// children based on the match state received from the server via WebSocket.
+///
+/// Provide custom [playerBuilder] and [projectileBuilder] callbacks to
+/// use your own components with the [AsobiPlayer] and [AsobiProjectile] mixins.
 ///
 /// ```dart
 /// add(AsobiNetworkSync(
 ///   client: asobi,
 ///   pixelsPerUnit: 50,
+///   playerBuilder: (id, isLocal) {
+///     final p = MyPlayerSprite()..initPlayer(id: id, local: isLocal);
+///     return p;
+///   },
 ///   onStateUpdate: (state) => updateHud(state),
 ///   onMatchFinished: (result) => showResults(result),
 /// ));
@@ -34,8 +43,8 @@ class AsobiNetworkSync extends Component {
   final void Function(Map<String, dynamic> state)? onStateUpdate;
   final void Function(Map<String, dynamic> result)? onMatchFinished;
 
-  final Map<String, AsobiPlayer> _players = {};
-  final Map<int, AsobiProjectile> _projectiles = {};
+  final Map<String, PositionComponent> _players = {};
+  final Map<int, PositionComponent> _projectiles = {};
   Map<String, dynamic> _latestState = {};
   String _myId = '';
 
@@ -85,10 +94,10 @@ class AsobiNetworkSync extends Component {
   Map<String, dynamic> get latestState => _latestState;
 
   /// The local player component, if present.
-  AsobiPlayer? get localPlayer => _players[_myId];
+  PositionComponent? get localPlayer => _players[_myId];
 
   /// All player components by ID.
-  Map<String, AsobiPlayer> get players => Map.unmodifiable(_players);
+  Map<String, PositionComponent> get players => Map.unmodifiable(_players);
 
   /// Time remaining in milliseconds.
   double get timeRemainingMs =>
@@ -111,16 +120,7 @@ class AsobiNetworkSync extends Component {
         add(player);
       }
 
-      final player = _players[pid]!;
-      player.applyServerState(data, pixelsPerUnit);
-
-      if (player.isDead) {
-        player.color = const Color(0xFF888888);
-      } else if (isMe) {
-        player.color = const Color(0xFF00FFFF);
-      } else {
-        player.color = const Color(0xFFFF4444);
-      }
+      (_players[pid]! as AsobiPlayer).applyServerState(data, pixelsPerUnit);
     }
 
     for (final pid in _players.keys.toList()) {
@@ -144,12 +144,12 @@ class AsobiNetworkSync extends Component {
 
       if (!_projectiles.containsKey(id)) {
         final projectile = projectileBuilder?.call(id, owner, isLocal) ??
-            AsobiProjectile(projectileId: id, owner: owner, isLocal: isLocal);
+            _defaultProjectile(id, owner, isLocal);
         _projectiles[id] = projectile;
         add(projectile);
       }
 
-      _projectiles[id]!.applyServerState(data, pixelsPerUnit);
+      (_projectiles[id]! as AsobiProjectile).applyServerState(data, pixelsPerUnit);
     }
 
     for (final id in _projectiles.keys.toList()) {
@@ -160,11 +160,25 @@ class AsobiNetworkSync extends Component {
     }
   }
 
-  AsobiPlayer _defaultPlayer(String pid, bool isMe) {
-    return AsobiPlayer(
-      playerId: pid,
-      isLocal: isMe,
-      size: Vector2.all(0.64),
-    );
+  PositionComponent _defaultPlayer(String pid, bool isMe) {
+    return _DefaultPlayer(size: Vector2.all(0.64))
+      ..initPlayer(id: pid, local: isMe);
   }
+
+  PositionComponent _defaultProjectile(int id, String owner, bool isLocal) {
+    return _DefaultProjectile(radius: 0.15)
+      ..initProjectile(id: id, ownerId: owner, local: isLocal);
+  }
+}
+
+/// Minimal default player — a simple circle. Override via [playerBuilder].
+class _DefaultPlayer extends CircleComponent with AsobiPlayer {
+  _DefaultPlayer({required Vector2 size})
+      : super(radius: size.x / 2, anchor: Anchor.center, priority: 5);
+}
+
+/// Minimal default projectile — a small circle. Override via [projectileBuilder].
+class _DefaultProjectile extends CircleComponent with AsobiProjectile {
+  _DefaultProjectile({required double radius})
+      : super(radius: radius, anchor: Anchor.center, priority: 3);
 }

--- a/lib/src/asobi_player.dart
+++ b/lib/src/asobi_player.dart
@@ -1,38 +1,32 @@
-import 'dart:ui';
 import 'package:flame/components.dart';
-import 'package:flutter/painting.dart' show TextPainter, TextSpan, TextStyle, TextDirection;
 
-/// A networked player component with position interpolation.
+/// A mixin for networked player components with position interpolation.
 ///
-/// Updates position smoothly via [applyServerState] which lerps
-/// from the current position to the server-provided target.
-class AsobiPlayer extends PositionComponent {
-  final String playerId;
-  final bool isLocal;
-  final double lerpSpeed;
+/// Apply to any [PositionComponent] to add multiplayer state synchronization.
+/// The component's position is smoothly interpolated towards the server target.
+///
+/// ```dart
+/// class MyPlayer extends SpriteComponent with AsobiPlayer {
+///   MyPlayer({required super.playerId});
+/// }
+/// ```
+mixin AsobiPlayer on PositionComponent {
+  late final String playerId;
+  bool isLocal = false;
+  double lerpSpeed = 0.3;
 
-  Color color;
-  int hp;
-  int kills;
-  int deaths;
-  String label;
+  int hp = 100;
+  int kills = 0;
+  int deaths = 0;
+  String label = '';
 
   Vector2 _targetPosition = Vector2.zero();
 
-  AsobiPlayer({
-    required this.playerId,
-    this.isLocal = false,
-    this.lerpSpeed = 0.3,
-    this.color = const Color(0xFFFF4444),
-    this.hp = 100,
-    this.kills = 0,
-    this.deaths = 0,
-    String? label,
-    super.position,
-    super.size,
-    super.anchor = Anchor.center,
-    super.priority = 5,
-  }) : label = label ?? (isLocal ? 'YOU' : playerId.substring(0, 8)) {
+  void initPlayer({required String id, bool local = false, double lerp = 0.3, String? playerLabel}) {
+    playerId = id;
+    isLocal = local;
+    lerpSpeed = lerp;
+    label = playerLabel ?? (local ? 'YOU' : id.substring(0, (id.length < 8) ? id.length : 8));
     _targetPosition = position.clone();
   }
 
@@ -53,35 +47,5 @@ class AsobiPlayer extends PositionComponent {
   void update(double dt) {
     super.update(dt);
     position.lerp(_targetPosition, lerpSpeed);
-  }
-
-  @override
-  void render(Canvas canvas) {
-    // Body circle
-    final bodyPaint = Paint()..color = color;
-    canvas.drawCircle(
-      Offset(size.x / 2, size.y / 2),
-      size.x / 2,
-      bodyPaint,
-    );
-
-    // HP bar background
-    final hpBgPaint = Paint()..color = const Color(0xFF000000);
-    canvas.drawRect(Rect.fromLTWH(0, size.y + 0.05, size.x, 0.08), hpBgPaint);
-
-    // HP bar
-    final hpPaint = Paint()..color = const Color(0xFF00FF00);
-    final hpWidth = size.x * (hp / 100).clamp(0.0, 1.0);
-    canvas.drawRect(Rect.fromLTWH(0, size.y + 0.05, hpWidth, 0.08), hpPaint);
-
-    // Label
-    final tp = TextPainter(
-      text: TextSpan(
-        text: label,
-        style: TextStyle(fontSize: 1.4, color: const Color(0xFFFFFFFF)),
-      ),
-      textDirection: TextDirection.ltr,
-    )..layout();
-    tp.paint(canvas, Offset((size.x - tp.width) / 2, -1.6));
   }
 }

--- a/lib/src/asobi_projectile.dart
+++ b/lib/src/asobi_projectile.dart
@@ -1,25 +1,24 @@
-import 'dart:ui';
 import 'package:flame/components.dart';
 
-/// A networked projectile component.
+/// A mixin for networked projectile components.
 ///
-/// Position is set directly from server state (no interpolation —
-/// projectiles move fast enough that lerping looks worse).
-class AsobiProjectile extends CircleComponent {
-  final int projectileId;
-  final String owner;
-  final bool isLocal;
+/// Apply to any [PositionComponent] to add server state synchronization.
+/// Position is set directly (no interpolation — projectiles move too fast).
+///
+/// ```dart
+/// class MyBullet extends CircleComponent with AsobiProjectile {
+///   MyBullet({required super.radius});
+/// }
+/// ```
+mixin AsobiProjectile on PositionComponent {
+  late final int projectileId;
+  late final String owner;
+  bool isLocal = false;
 
-  AsobiProjectile({
-    required this.projectileId,
-    required this.owner,
-    this.isLocal = false,
-    super.position,
-    double radius = 0.15,
-    super.anchor = Anchor.center,
-    super.priority = 3,
-  }) : super(radius: radius) {
-    paint = Paint()..color = isLocal ? const Color(0xFFFFFF00) : const Color(0xFFFFFFFF);
+  void initProjectile({required int id, required String ownerId, bool local = false}) {
+    projectileId = id;
+    owner = ownerId;
+    isLocal = local;
   }
 
   /// Apply position from server state.


### PR DESCRIPTION
## Summary
- `AsobiPlayer` and `AsobiProjectile` are now mixins on `PositionComponent` instead of concrete classes
- Users can apply them to any component (SpriteComponent, CircleComponent, custom components)
- Rendering removed from the library — users control their own visuals
- Added `example/pubspec.yaml`
- Updated example to show the mixin pattern with custom `ArenaPlayer` and `ArenaBullet` classes

Based on feedback from @spydon (Flame core team).

## Test plan
- [ ] Example builds and runs
- [ ] Custom player/projectile components work with AsobiNetworkSync