### PR TITLE
refactor: convert input sender and matchmaker to mixins

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -7,7 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart' show KeyEventResult;
 import 'package:flame_asobi/flame_asobi.dart';
 
-/// Minimal multiplayer arena game using flame_asobi.
+/// Minimal multiplayer arena game using flame_asobi mixins.
 void main() {
   runApp(GameWidget(game: ArenaGame()));
 }
@@ -41,21 +41,38 @@ class ArenaBullet extends CircleComponent with AsobiProjectile {
 }
 
 class ArenaGame extends FlameGame
-    with HasAsobi, KeyboardEvents, MouseMovementDetector, TapCallbacks {
-  late final AsobiInputSender _input;
+    with
+        HasAsobi,
+        HasAsobiMatchmaker,
+        HasAsobiInput,
+        KeyboardEvents,
+        KeyboardHandler,
+        MouseMovementDetector,
+        TapCallbacks {
   late final AsobiNetworkSync _sync;
+
+  @override
+  AsobiClient get inputClient => asobi;
+
+  @override
+  AsobiClient get matchmakerClient => asobi;
+
+  @override
+  String get matchmakerMode => 'arena';
+
+  @override
+  double get inputPixelsPerUnit => 50;
 
   @override
   Future<void> onLoad() async {
     await asobiConnect('localhost', port: 8084);
     await asobi.auth.register('player_${DateTime.now().millisecond}', 'pass');
-    await asobi.realtime.connect();
-
-    asobi.realtime.onMatchmakerMatched.stream.listen((_) => _startGame());
-    await asobi.realtime.addToMatchmaker(mode: 'arena');
+    await connectMatchmaker();
+    findMatch();
   }
 
-  void _startGame() {
+  @override
+  void onMatchmakerMatched(Map<String, dynamic> payload) {
     _sync = AsobiNetworkSync(
       client: asobi,
       pixelsPerUnit: 50,
@@ -68,9 +85,6 @@ class ArenaGame extends FlameGame
       },
     );
     world.add(_sync);
-
-    _input = AsobiInputSender(client: asobi, pixelsPerUnit: 50);
-    world.add(_input);
 
     camera.viewfinder.position = Vector2(8, 6);
     camera.viewfinder.zoom = size.y / 13;
@@ -86,21 +100,21 @@ class ArenaGame extends FlameGame
 
   @override
   KeyEventResult onKeyEvent(KeyEvent event, Set<LogicalKeyboardKey> keysPressed) {
-    _input.onKeyEvent(event, keysPressed);
+    super.onKeyEvent(event, keysPressed);
     return KeyEventResult.handled;
   }
 
   @override
   void onMouseMove(PointerHoverInfo info) {
-    _input.updateMousePosition(camera.viewfinder.globalToLocal(info.eventPosition.global));
+    updateMousePosition(camera.viewfinder.globalToLocal(info.eventPosition.global));
   }
 
   @override
   void onTapDown(TapDownEvent event) {
-    _input.setMouseDown(true);
-    _input.updateMousePosition(camera.viewfinder.globalToLocal(event.canvasPosition));
+    setMouseDown(true);
+    updateMousePosition(camera.viewfinder.globalToLocal(event.canvasPosition));
   }
 
   @override
-  void onTapUp(TapUpEvent event) => _input.setMouseDown(false);
+  void onTapUp(TapUpEvent event) => setMouseDown(false);
 }

--- a/lib/src/asobi_input_sender.dart
+++ b/lib/src/asobi_input_sender.dart
@@ -1,44 +1,36 @@
 import 'package:asobi/asobi.dart';
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
-import 'package:flame/game.dart';
 import 'package:flutter/services.dart';
 
-/// Component that captures keyboard and mouse input and sends it
+/// Mixin that captures keyboard and mouse input and sends it
 /// to the Asobi backend as match input.
 ///
-/// Attach to a [FlameGame] that uses [KeyboardEvents] and [TapCallbacks].
+/// Apply to any [Component] that uses [KeyboardHandler].
 ///
 /// ```dart
-/// add(AsobiInputSender(
-///   client: asobi,
-///   pixelsPerUnit: 50,
-/// ));
+/// class MyGame extends FlameGame with HasAsobi, HasAsobiInput, KeyboardEvents {
+///   @override
+///   AsobiClient get inputClient => asobi;
+/// }
 /// ```
-class AsobiInputSender extends Component with KeyboardHandler {
-  final AsobiClient client;
-  final double pixelsPerUnit;
+mixin HasAsobiInput on Component, KeyboardHandler {
+  /// The Asobi client to send input through.
+  AsobiClient get inputClient;
+
+  /// Pixels per world unit for coordinate conversion.
+  double get inputPixelsPerUnit => 50;
 
   final Set<LogicalKeyboardKey> _keysPressed = {};
   Vector2 _mouseWorld = Vector2.zero();
   bool _mouseDown = false;
 
   /// Keys mapped to movement directions. Override to customize.
-  LogicalKeyboardKey keyUp;
-  LogicalKeyboardKey keyDown;
-  LogicalKeyboardKey keyLeft;
-  LogicalKeyboardKey keyRight;
-  LogicalKeyboardKey keyShoot;
-
-  AsobiInputSender({
-    required this.client,
-    this.pixelsPerUnit = 50,
-    this.keyUp = LogicalKeyboardKey.keyW,
-    this.keyDown = LogicalKeyboardKey.keyS,
-    this.keyLeft = LogicalKeyboardKey.keyA,
-    this.keyRight = LogicalKeyboardKey.keyD,
-    this.keyShoot = LogicalKeyboardKey.space,
-  });
+  LogicalKeyboardKey get keyUp => LogicalKeyboardKey.keyW;
+  LogicalKeyboardKey get keyDown => LogicalKeyboardKey.keyS;
+  LogicalKeyboardKey get keyLeft => LogicalKeyboardKey.keyA;
+  LogicalKeyboardKey get keyRight => LogicalKeyboardKey.keyD;
+  LogicalKeyboardKey get keyShoot => LogicalKeyboardKey.space;
 
   @override
   bool onKeyEvent(KeyEvent event, Set<LogicalKeyboardKey> keysPressed) {
@@ -69,14 +61,14 @@ class AsobiInputSender extends Component with KeyboardHandler {
 
     if (!(up || down || left || right || shoot)) return;
 
-    client.realtime.sendMatchInput({
+    inputClient.realtime.sendMatchInput({
       'up': up,
       'down': down,
       'left': left,
       'right': right,
       'shoot': shoot,
-      'aim_x': _mouseWorld.x * pixelsPerUnit,
-      'aim_y': _mouseWorld.y * pixelsPerUnit,
+      'aim_x': _mouseWorld.x * inputPixelsPerUnit,
+      'aim_y': _mouseWorld.y * inputPixelsPerUnit,
     });
   }
 }

--- a/lib/src/asobi_matchmaker.dart
+++ b/lib/src/asobi_matchmaker.dart
@@ -2,90 +2,96 @@ import 'dart:async';
 import 'package:asobi/asobi.dart';
 import 'package:flame/components.dart';
 
-/// Component that manages matchmaking lifecycle.
-///
-/// Connects to the server, queues for a match, and fires callbacks.
+/// Mixin that manages matchmaking lifecycle on any [Component].
 ///
 /// ```dart
-/// add(AsobiMatchmaker(
-///   client: asobi,
-///   mode: 'arena',
-///   onConnected: () => print('ready'),
-///   onMatched: (payload) => startGame(),
-/// ));
+/// class MyGame extends FlameGame with HasAsobi, HasAsobiMatchmaker {
+///   @override
+///   AsobiClient get matchmakerClient => asobi;
+///
+///   @override
+///   String get matchmakerMode => 'arena';
+///
+///   @override
+///   void onMatchmakerConnected() => print('ready');
+///
+///   @override
+///   void onMatchmakerMatched(Map<String, dynamic> payload) => startGame();
+/// }
 /// ```
-class AsobiMatchmaker extends Component {
-  final AsobiClient client;
-  final String mode;
-  final void Function()? onConnected;
-  final void Function(Map<String, dynamic> payload)? onMatched;
-  final void Function(Map<String, dynamic> error)? onError;
+mixin HasAsobiMatchmaker on Component {
+  /// The Asobi client used for matchmaking.
+  AsobiClient get matchmakerClient;
 
-  bool _connected = false;
-  bool _searching = false;
-  double _searchTime = 0;
+  /// Game mode to search for.
+  String get matchmakerMode => 'default';
 
-  StreamSubscription? _connectedSub;
-  StreamSubscription? _matchedSub;
-  StreamSubscription? _errorSub;
+  bool _mmConnected = false;
+  bool _mmSearching = false;
+  double _mmSearchTime = 0;
 
-  AsobiMatchmaker({
-    required this.client,
-    this.mode = 'default',
-    this.onConnected,
-    this.onMatched,
-    this.onError,
-  });
+  StreamSubscription? _mmConnectedSub;
+  StreamSubscription? _mmMatchedSub;
+  StreamSubscription? _mmErrorSub;
 
   /// Whether the WebSocket is connected and ready.
-  bool get isConnected => _connected;
+  bool get isConnected => _mmConnected;
 
   /// Whether currently searching for a match.
-  bool get isSearching => _searching;
+  bool get isSearching => _mmSearching;
 
   /// Seconds spent searching.
-  double get searchTime => _searchTime;
+  double get searchTime => _mmSearchTime;
 
-  /// Connect to the server WebSocket.
-  Future<void> connect() async {
-    _connectedSub = client.realtime.onConnected.stream.listen((_) {
-      _connected = true;
-      onConnected?.call();
+  /// Called when WebSocket connects.
+  void onMatchmakerConnected() {}
+
+  /// Called when a match is found.
+  void onMatchmakerMatched(Map<String, dynamic> payload) {}
+
+  /// Called on matchmaker error.
+  void onMatchmakerError(Map<String, dynamic> error) {}
+
+  /// Connect to the server WebSocket and start listening.
+  Future<void> connectMatchmaker() async {
+    _mmConnectedSub = matchmakerClient.realtime.onConnected.stream.listen((_) {
+      _mmConnected = true;
+      onMatchmakerConnected();
     });
-    _matchedSub = client.realtime.onMatchmakerMatched.stream.listen((payload) {
-      _searching = false;
-      onMatched?.call(payload);
+    _mmMatchedSub = matchmakerClient.realtime.onMatchmakerMatched.stream.listen((payload) {
+      _mmSearching = false;
+      onMatchmakerMatched(payload);
     });
-    _errorSub = client.realtime.onError.stream.listen((err) {
-      _searching = false;
-      onError?.call(err);
+    _mmErrorSub = matchmakerClient.realtime.onError.stream.listen((err) {
+      _mmSearching = false;
+      onMatchmakerError(err);
     });
-    await client.realtime.connect();
+    await matchmakerClient.realtime.connect();
   }
 
   /// Start searching for a match.
   void findMatch() {
-    _searching = true;
-    _searchTime = 0;
-    client.realtime.addToMatchmaker(mode: mode);
+    _mmSearching = true;
+    _mmSearchTime = 0;
+    matchmakerClient.realtime.addToMatchmaker(mode: matchmakerMode);
   }
 
   /// Cancel the current search.
   void cancelSearch() {
-    _searching = false;
+    _mmSearching = false;
   }
 
   @override
   void update(double dt) {
     super.update(dt);
-    if (_searching) _searchTime += dt;
+    if (_mmSearching) _mmSearchTime += dt;
   }
 
   @override
   void onRemove() {
-    _connectedSub?.cancel();
-    _matchedSub?.cancel();
-    _errorSub?.cancel();
+    _mmConnectedSub?.cancel();
+    _mmMatchedSub?.cancel();
+    _mmErrorSub?.cancel();
     super.onRemove();
   }
 }


### PR DESCRIPTION
## Summary
- `HasAsobiInput` mixin replaces `AsobiInputSender` component — mix directly into game class
- `HasAsobiMatchmaker` mixin replaces `AsobiMatchmaker` component — override callbacks instead of passing them
- Example updated to show the full mixin-based approach: `HasAsobi + HasAsobiMatchmaker + HasAsobiInput`

## Test plan
- [ ] Example builds and runs
- [ ] Input sending works via mixin
- [ ] Matchmaker lifecycle works via mixin callbacks