### PR TITLE
refactor: typed models, required builders, input tick rate

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -7,12 +7,10 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart' show KeyEventResult;
 import 'package:flame_asobi/flame_asobi.dart';
 
-/// Minimal multiplayer arena game using flame_asobi mixins.
 void main() {
   runApp(GameWidget(game: ArenaGame()));
 }
 
-/// Custom player with sprite-friendly rendering.
 class ArenaPlayer extends CircleComponent with AsobiPlayer {
   ArenaPlayer({required Vector2 size})
       : super(radius: size.x / 2, anchor: Anchor.center, priority: 5);
@@ -28,7 +26,6 @@ class ArenaPlayer extends CircleComponent with AsobiPlayer {
   }
 }
 
-/// Custom projectile.
 class ArenaBullet extends CircleComponent with AsobiProjectile {
   ArenaBullet()
       : super(radius: 0.15, anchor: Anchor.center, priority: 3);
@@ -46,7 +43,6 @@ class ArenaGame extends FlameGame
         HasAsobiMatchmaker,
         HasAsobiInput,
         KeyboardEvents,
-        KeyboardHandler,
         MouseMovementDetector,
         TapCallbacks {
   late final AsobiNetworkSync _sync;
@@ -72,14 +68,14 @@ class ArenaGame extends FlameGame
   }
 
   @override
-  void onMatchmakerMatched(Map<String, dynamic> payload) {
+  void onMatchmakerMatched(MatchmakerMatch match) {
     _sync = AsobiNetworkSync(
       client: asobi,
       pixelsPerUnit: 50,
-      playerBuilder: (id, isLocal) =>
-          ArenaPlayer(size: Vector2.all(0.64))..initPlayer(id: id, local: isLocal),
-      projectileBuilder: (id, owner, isLocal) =>
-          ArenaBullet()..initProjectile(id: id, ownerId: owner, local: isLocal),
+      playerBuilder: (playerId, isLocal) =>
+          ArenaPlayer(size: Vector2.all(0.64)),
+      projectileBuilder: (projectileId, owner, isLocal) =>
+          ArenaBullet(),
       onMatchFinished: (result) {
         // Handle game over
       },
@@ -100,7 +96,7 @@ class ArenaGame extends FlameGame
 
   @override
   KeyEventResult onKeyEvent(KeyEvent event, Set<LogicalKeyboardKey> keysPressed) {
-    super.onKeyEvent(event, keysPressed);
+    handleKeyEvent(event, keysPressed);
     return KeyEventResult.handled;
   }
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,12 +3,12 @@ description: Example multiplayer arena game using flame_asobi.
 publish_to: none
 
 environment:
-  sdk: ">=3.4.0 <4.0.0"
-  flutter: ">=3.22.0"
+  sdk: ">=3.11.0 <4.0.0"
+  flutter: ">=3.41.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  flame: ">=1.18.0 <2.0.0"
+  flame: ^1.36.0
   flame_asobi:
     path: ../

--- a/lib/flame_asobi.dart
+++ b/lib/flame_asobi.dart
@@ -1,7 +1,7 @@
+export 'package:asobi/asobi.dart';
 export 'src/has_asobi.dart';
 export 'src/asobi_network_sync.dart';
 export 'src/asobi_player.dart';
 export 'src/asobi_projectile.dart';
 export 'src/asobi_matchmaker.dart';
 export 'src/asobi_input_sender.dart';
-export 'package:asobi/asobi.dart' show AsobiClient;

--- a/lib/src/asobi_input_sender.dart
+++ b/lib/src/asobi_input_sender.dart
@@ -1,50 +1,37 @@
 import 'package:asobi/asobi.dart';
 import 'package:flame/components.dart';
-import 'package:flame/events.dart';
 import 'package:flutter/services.dart';
 
-/// Mixin that captures keyboard and mouse input and sends it
-/// to the Asobi backend as match input.
-///
-/// Apply to any [Component] that uses [KeyboardHandler].
-///
-/// ```dart
-/// class MyGame extends FlameGame with HasAsobi, HasAsobiInput, KeyboardEvents {
-///   @override
-///   AsobiClient get inputClient => asobi;
-/// }
-/// ```
-mixin HasAsobiInput on Component, KeyboardHandler {
-  /// The Asobi client to send input through.
+mixin HasAsobiInput on Component {
   AsobiClient get inputClient;
 
-  /// Pixels per world unit for coordinate conversion.
   double get inputPixelsPerUnit => 50;
+
+  /// Minimum interval between input sends in seconds.
+  /// Default 0.1 (10Hz) to match typical server tick rate.
+  double get inputSendInterval => 0.1;
 
   final Set<LogicalKeyboardKey> _keysPressed = {};
   Vector2 _mouseWorld = Vector2.zero();
   bool _mouseDown = false;
+  double _inputAccumulator = 0;
 
-  /// Keys mapped to movement directions. Override to customize.
   LogicalKeyboardKey get keyUp => LogicalKeyboardKey.keyW;
   LogicalKeyboardKey get keyDown => LogicalKeyboardKey.keyS;
   LogicalKeyboardKey get keyLeft => LogicalKeyboardKey.keyA;
   LogicalKeyboardKey get keyRight => LogicalKeyboardKey.keyD;
   LogicalKeyboardKey get keyShoot => LogicalKeyboardKey.space;
 
-  @override
-  bool onKeyEvent(KeyEvent event, Set<LogicalKeyboardKey> keysPressed) {
+  /// Call from your game's key event handler to track pressed keys.
+  void handleKeyEvent(KeyEvent event, Set<LogicalKeyboardKey> keysPressed) {
     _keysPressed.clear();
     _keysPressed.addAll(keysPressed);
-    return false;
   }
 
-  /// Call from the game's mouse/tap handlers to update aim position.
   void updateMousePosition(Vector2 worldPosition) {
     _mouseWorld = worldPosition;
   }
 
-  /// Call from the game's tap handlers.
   void setMouseDown(bool down) {
     _mouseDown = down;
   }
@@ -52,6 +39,10 @@ mixin HasAsobiInput on Component, KeyboardHandler {
   @override
   void update(double dt) {
     super.update(dt);
+
+    _inputAccumulator += dt;
+    if (_inputAccumulator < inputSendInterval) return;
+    _inputAccumulator = 0;
 
     final up = _keysPressed.contains(keyUp);
     final down = _keysPressed.contains(keyDown);
@@ -61,14 +52,14 @@ mixin HasAsobiInput on Component, KeyboardHandler {
 
     if (!(up || down || left || right || shoot)) return;
 
-    inputClient.realtime.sendMatchInput({
-      'up': up,
-      'down': down,
-      'left': left,
-      'right': right,
-      'shoot': shoot,
-      'aim_x': _mouseWorld.x * inputPixelsPerUnit,
-      'aim_y': _mouseWorld.y * inputPixelsPerUnit,
-    });
+    inputClient.realtime.sendMatchInput(MatchInput(
+      up: up,
+      down: down,
+      left: left,
+      right: right,
+      shoot: shoot,
+      aimX: _mouseWorld.x * inputPixelsPerUnit,
+      aimY: _mouseWorld.y * inputPixelsPerUnit,
+    ));
   }
 }

--- a/lib/src/asobi_matchmaker.dart
+++ b/lib/src/asobi_matchmaker.dart
@@ -2,96 +2,68 @@ import 'dart:async';
 import 'package:asobi/asobi.dart';
 import 'package:flame/components.dart';
 
-/// Mixin that manages matchmaking lifecycle on any [Component].
-///
-/// ```dart
-/// class MyGame extends FlameGame with HasAsobi, HasAsobiMatchmaker {
-///   @override
-///   AsobiClient get matchmakerClient => asobi;
-///
-///   @override
-///   String get matchmakerMode => 'arena';
-///
-///   @override
-///   void onMatchmakerConnected() => print('ready');
-///
-///   @override
-///   void onMatchmakerMatched(Map<String, dynamic> payload) => startGame();
-/// }
-/// ```
 mixin HasAsobiMatchmaker on Component {
-  /// The Asobi client used for matchmaking.
   AsobiClient get matchmakerClient;
 
-  /// Game mode to search for.
   String get matchmakerMode => 'default';
 
-  bool _mmConnected = false;
-  bool _mmSearching = false;
-  double _mmSearchTime = 0;
+  bool _connected = false;
+  bool _searching = false;
+  double _searchTime = 0;
 
-  StreamSubscription? _mmConnectedSub;
-  StreamSubscription? _mmMatchedSub;
-  StreamSubscription? _mmErrorSub;
+  StreamSubscription<void>? _connectedSub;
+  StreamSubscription<MatchmakerMatch>? _matchedSub;
+  StreamSubscription<RealtimeError>? _errorSub;
 
-  /// Whether the WebSocket is connected and ready.
-  bool get isConnected => _mmConnected;
+  bool get isConnected => _connected;
 
-  /// Whether currently searching for a match.
-  bool get isSearching => _mmSearching;
+  bool get isSearching => _searching;
 
-  /// Seconds spent searching.
-  double get searchTime => _mmSearchTime;
+  double get searchTime => _searchTime;
 
-  /// Called when WebSocket connects.
   void onMatchmakerConnected() {}
 
-  /// Called when a match is found.
-  void onMatchmakerMatched(Map<String, dynamic> payload) {}
+  void onMatchmakerMatched(MatchmakerMatch match) {}
 
-  /// Called on matchmaker error.
-  void onMatchmakerError(Map<String, dynamic> error) {}
+  void onMatchmakerError(RealtimeError error) {}
 
-  /// Connect to the server WebSocket and start listening.
   Future<void> connectMatchmaker() async {
-    _mmConnectedSub = matchmakerClient.realtime.onConnected.stream.listen((_) {
-      _mmConnected = true;
+    _connectedSub = matchmakerClient.realtime.onConnected.stream.listen((_) {
+      _connected = true;
       onMatchmakerConnected();
     });
-    _mmMatchedSub = matchmakerClient.realtime.onMatchmakerMatched.stream.listen((payload) {
-      _mmSearching = false;
-      onMatchmakerMatched(payload);
+    _matchedSub = matchmakerClient.realtime.onMatchmakerMatched.stream.listen((match) {
+      _searching = false;
+      onMatchmakerMatched(match);
     });
-    _mmErrorSub = matchmakerClient.realtime.onError.stream.listen((err) {
-      _mmSearching = false;
-      onMatchmakerError(err);
+    _errorSub = matchmakerClient.realtime.onError.stream.listen((error) {
+      _searching = false;
+      onMatchmakerError(error);
     });
     await matchmakerClient.realtime.connect();
   }
 
-  /// Start searching for a match.
   void findMatch() {
-    _mmSearching = true;
-    _mmSearchTime = 0;
+    _searching = true;
+    _searchTime = 0;
     matchmakerClient.realtime.addToMatchmaker(mode: matchmakerMode);
   }
 
-  /// Cancel the current search.
   void cancelSearch() {
-    _mmSearching = false;
+    _searching = false;
   }
 
   @override
   void update(double dt) {
     super.update(dt);
-    if (_mmSearching) _mmSearchTime += dt;
+    if (_searching) _searchTime += dt;
   }
 
   @override
   void onRemove() {
-    _mmConnectedSub?.cancel();
-    _mmMatchedSub?.cancel();
-    _mmErrorSub?.cancel();
+    _connectedSub?.cancel();
+    _matchedSub?.cancel();
+    _errorSub?.cancel();
     super.onRemove();
   }
 }

--- a/lib/src/asobi_network_sync.dart
+++ b/lib/src/asobi_network_sync.dart
@@ -5,57 +5,31 @@ import 'package:flame/components.dart';
 import 'asobi_player.dart';
 import 'asobi_projectile.dart';
 
-/// Callback for building a player component from server data.
-///
-/// Must return a [PositionComponent] with the [AsobiPlayer] mixin applied.
 typedef PlayerBuilder = PositionComponent Function(String playerId, bool isLocal);
 
-/// Callback for building a projectile component from server data.
-///
-/// Must return a [PositionComponent] with the [AsobiProjectile] mixin applied.
 typedef ProjectileBuilder = PositionComponent Function(int id, String owner, bool isLocal);
 
-/// Synchronizes server match state with Flame components.
-///
-/// Automatically creates, updates, and removes player and projectile
-/// children based on the match state received from the server via WebSocket.
-///
-/// Provide custom [playerBuilder] and [projectileBuilder] callbacks to
-/// use your own components with the [AsobiPlayer] and [AsobiProjectile] mixins.
-///
-/// ```dart
-/// add(AsobiNetworkSync(
-///   client: asobi,
-///   pixelsPerUnit: 50,
-///   playerBuilder: (id, isLocal) {
-///     final p = MyPlayerSprite()..initPlayer(id: id, local: isLocal);
-///     return p;
-///   },
-///   onStateUpdate: (state) => updateHud(state),
-///   onMatchFinished: (result) => showResults(result),
-/// ));
-/// ```
 class AsobiNetworkSync extends Component {
   final AsobiClient client;
   final double pixelsPerUnit;
-  final PlayerBuilder? playerBuilder;
-  final ProjectileBuilder? projectileBuilder;
-  final void Function(Map<String, dynamic> state)? onStateUpdate;
-  final void Function(Map<String, dynamic> result)? onMatchFinished;
+  final PlayerBuilder playerBuilder;
+  final ProjectileBuilder projectileBuilder;
+  final void Function(MatchState state)? onStateUpdate;
+  final void Function(MatchResult result)? onMatchFinished;
 
   final Map<String, PositionComponent> _players = {};
   final Map<int, PositionComponent> _projectiles = {};
-  Map<String, dynamic> _latestState = {};
+  MatchState? _latestState;
   String _myId = '';
 
-  StreamSubscription? _stateSub;
-  StreamSubscription? _finishSub;
+  StreamSubscription<MatchState>? _stateSub;
+  StreamSubscription<MatchResult>? _finishSub;
 
   AsobiNetworkSync({
     required this.client,
+    required this.playerBuilder,
+    required this.projectileBuilder,
     this.pixelsPerUnit = 50,
-    this.playerBuilder,
-    this.projectileBuilder,
     this.onStateUpdate,
     this.onMatchFinished,
   });
@@ -64,12 +38,12 @@ class AsobiNetworkSync extends Component {
   Future<void> onLoad() async {
     _myId = client.playerId ?? '';
 
-    _stateSub = client.realtime.onMatchState.stream.listen((payload) {
-      _latestState = payload;
+    _stateSub = client.realtime.onMatchState.stream.listen((state) {
+      _latestState = state;
     });
 
-    _finishSub = client.realtime.onMatchFinished.stream.listen((payload) {
-      onMatchFinished?.call(payload);
+    _finishSub = client.realtime.onMatchFinished.stream.listen((result) {
+      onMatchFinished?.call(result);
     });
   }
 
@@ -83,102 +57,73 @@ class AsobiNetworkSync extends Component {
   @override
   void update(double dt) {
     super.update(dt);
-    if (_latestState.isEmpty) return;
+    final state = _latestState;
+    if (state == null) return;
 
-    _syncPlayers();
-    _syncProjectiles();
-    onStateUpdate?.call(_latestState);
+    _syncPlayers(state);
+    _syncProjectiles(state);
+    onStateUpdate?.call(state);
   }
 
-  /// The latest match state received from the server.
-  Map<String, dynamic> get latestState => _latestState;
+  MatchState? get latestState => _latestState;
 
-  /// The local player component, if present.
   PositionComponent? get localPlayer => _players[_myId];
 
-  /// All player components by ID.
   Map<String, PositionComponent> get players => Map.unmodifiable(_players);
 
-  /// Time remaining in milliseconds.
-  double get timeRemainingMs =>
-      (_latestState['time_remaining'] as num?)?.toDouble() ?? 0;
+  double get timeRemainingMs => _latestState?.timeRemaining ?? 0;
 
-  void _syncPlayers() {
-    final players = _latestState['players'] as Map<String, dynamic>? ?? {};
+  void _syncPlayers(MatchState state) {
     final seenIds = <String>{};
 
-    for (final entry in players.entries) {
-      final pid = entry.key;
-      final data = entry.value as Map<String, dynamic>;
-      final isMe = pid == _myId;
-      seenIds.add(pid);
+    for (final entry in state.players.entries) {
+      final playerId = entry.key;
+      final playerState = entry.value;
+      final isMe = playerId == _myId;
+      seenIds.add(playerId);
 
-      if (!_players.containsKey(pid)) {
-        final player = playerBuilder?.call(pid, isMe) ??
-            _defaultPlayer(pid, isMe);
-        _players[pid] = player;
+      if (!_players.containsKey(playerId)) {
+        final player = playerBuilder(playerId, isMe);
+        (player as AsobiPlayer).initPlayer(id: playerId, local: isMe);
+        _players[playerId] = player;
         add(player);
       }
 
-      (_players[pid]! as AsobiPlayer).applyServerState(data, pixelsPerUnit);
+      (_players[playerId]! as AsobiPlayer).applyServerState(playerState, pixelsPerUnit);
     }
 
-    for (final pid in _players.keys.toList()) {
-      if (!seenIds.contains(pid)) {
-        _players[pid]!.removeFromParent();
-        _players.remove(pid);
+    for (final playerId in _players.keys.toList()) {
+      if (!seenIds.contains(playerId)) {
+        _players[playerId]!.removeFromParent();
+        _players.remove(playerId);
       }
     }
   }
 
-  void _syncProjectiles() {
-    final projectiles = _latestState['projectiles'] as List<dynamic>? ?? [];
+  void _syncProjectiles(MatchState state) {
     final seenIds = <int>{};
 
-    for (final proj in projectiles) {
-      final data = proj as Map<String, dynamic>;
-      final id = (data['id'] as num).toInt();
-      final owner = data['owner'] as String? ?? '';
-      final isLocal = owner == _myId;
-      seenIds.add(id);
+    for (final projectileState in state.projectiles) {
+      final projectileId = projectileState.id;
+      final ownerId = projectileState.owner;
+      final isLocal = ownerId == _myId;
+      seenIds.add(projectileId);
 
-      if (!_projectiles.containsKey(id)) {
-        final projectile = projectileBuilder?.call(id, owner, isLocal) ??
-            _defaultProjectile(id, owner, isLocal);
-        _projectiles[id] = projectile;
+      if (!_projectiles.containsKey(projectileId)) {
+        final projectile = projectileBuilder(projectileId, ownerId, isLocal);
+        (projectile as AsobiProjectile).initProjectile(id: projectileId, ownerId: ownerId, local: isLocal);
+        _projectiles[projectileId] = projectile;
         add(projectile);
       }
 
-      (_projectiles[id]! as AsobiProjectile).applyServerState(data, pixelsPerUnit);
+      (_projectiles[projectileId]! as AsobiProjectile).applyServerState(projectileState, pixelsPerUnit);
     }
 
-    for (final id in _projectiles.keys.toList()) {
-      if (!seenIds.contains(id)) {
-        _projectiles[id]!.removeFromParent();
-        _projectiles.remove(id);
+    for (final projectileId in _projectiles.keys.toList()) {
+      if (!seenIds.contains(projectileId)) {
+        _projectiles[projectileId]!.removeFromParent();
+        _projectiles.remove(projectileId);
       }
     }
   }
-
-  PositionComponent _defaultPlayer(String pid, bool isMe) {
-    return _DefaultPlayer(size: Vector2.all(0.64))
-      ..initPlayer(id: pid, local: isMe);
-  }
-
-  PositionComponent _defaultProjectile(int id, String owner, bool isLocal) {
-    return _DefaultProjectile(radius: 0.15)
-      ..initProjectile(id: id, ownerId: owner, local: isLocal);
-  }
-}
-
-/// Minimal default player — a simple circle. Override via [playerBuilder].
-class _DefaultPlayer extends CircleComponent with AsobiPlayer {
-  _DefaultPlayer({required Vector2 size})
-      : super(radius: size.x / 2, anchor: Anchor.center, priority: 5);
-}
-
-/// Minimal default projectile — a small circle. Override via [projectileBuilder].
-class _DefaultProjectile extends CircleComponent with AsobiProjectile {
-  _DefaultProjectile({required double radius})
-      : super(radius: radius, anchor: Anchor.center, priority: 3);
 }

--- a/lib/src/asobi_player.dart
+++ b/lib/src/asobi_player.dart
@@ -1,15 +1,6 @@
+import 'package:asobi/asobi.dart';
 import 'package:flame/components.dart';
 
-/// A mixin for networked player components with position interpolation.
-///
-/// Apply to any [PositionComponent] to add multiplayer state synchronization.
-/// The component's position is smoothly interpolated towards the server target.
-///
-/// ```dart
-/// class MyPlayer extends SpriteComponent with AsobiPlayer {
-///   MyPlayer({required super.playerId});
-/// }
-/// ```
 mixin AsobiPlayer on PositionComponent {
   late final String playerId;
   bool isLocal = false;
@@ -30,15 +21,14 @@ mixin AsobiPlayer on PositionComponent {
     _targetPosition = position.clone();
   }
 
-  /// Apply state received from the server. Position is interpolated.
-  void applyServerState(Map<String, dynamic> state, double pixelsPerUnit) {
+  void applyServerState(PlayerState state, double pixelsPerUnit) {
     _targetPosition = Vector2(
-      (state['x'] as num).toDouble() / pixelsPerUnit,
-      (state['y'] as num).toDouble() / pixelsPerUnit,
+      state.x / pixelsPerUnit,
+      state.y / pixelsPerUnit,
     );
-    hp = (state['hp'] as num?)?.toInt() ?? 0;
-    kills = (state['kills'] as num?)?.toInt() ?? 0;
-    deaths = (state['deaths'] as num?)?.toInt() ?? 0;
+    hp = state.hp;
+    kills = state.kills;
+    deaths = state.deaths;
   }
 
   bool get isDead => hp <= 0;

--- a/lib/src/asobi_projectile.dart
+++ b/lib/src/asobi_projectile.dart
@@ -1,15 +1,6 @@
+import 'package:asobi/asobi.dart';
 import 'package:flame/components.dart';
 
-/// A mixin for networked projectile components.
-///
-/// Apply to any [PositionComponent] to add server state synchronization.
-/// Position is set directly (no interpolation — projectiles move too fast).
-///
-/// ```dart
-/// class MyBullet extends CircleComponent with AsobiProjectile {
-///   MyBullet({required super.radius});
-/// }
-/// ```
 mixin AsobiProjectile on PositionComponent {
   late final int projectileId;
   late final String owner;
@@ -21,11 +12,10 @@ mixin AsobiProjectile on PositionComponent {
     isLocal = local;
   }
 
-  /// Apply position from server state.
-  void applyServerState(Map<String, dynamic> state, double pixelsPerUnit) {
+  void applyServerState(ProjectileState state, double pixelsPerUnit) {
     position.setValues(
-      (state['x'] as num).toDouble() / pixelsPerUnit,
-      (state['y'] as num).toDouble() / pixelsPerUnit,
+      state.x / pixelsPerUnit,
+      state.y / pixelsPerUnit,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,16 +9,17 @@ topics:
   - matchmaking
 
 environment:
-  sdk: ">=3.4.0 <4.0.0"
-  flutter: ">=3.22.0"
+  sdk: ">=3.11.0 <4.0.0"
+  flutter: ">=3.41.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  flame: ">=1.18.0 <2.0.0"
+  flame: ^1.36.0
   asobi: ^0.1.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  lints: ^6.1.0
+  flame_test: ^1.16.0
+  mocktail: ^1.0.0


### PR DESCRIPTION
## Summary
- Replace all `Map<String, dynamic>` with typed models from asobi SDK (`PlayerState`, `ProjectileState`, `MatchState`, `MatchResult`, `MatchmakerMatch`)
- Make `playerBuilder`/`projectileBuilder` required in `AsobiNetworkSync` (removed `_DefaultPlayer`/`_DefaultProjectile`)
- Add configurable input tick rate (default 10Hz) to `HasAsobiInput`
- Remove `KeyboardHandler` constraint from `HasAsobiInput` — exposes `handleKeyEvent()` instead
- Fix `_mm*` abbreviations in `HasAsobiMatchmaker`
- Re-export full `package:asobi/asobi.dart` from barrel
- Bump Flame `^1.36.0`, Flutter `>=3.41.0`, add `flame_test`/`mocktail`

Depends on widgrensit/asobi-dart#8

## Test plan
- [ ] `flutter analyze lib/` passes clean
- [ ] `flutter analyze example/` passes clean
- [ ] Verify with local asobi-dart path override