### PR TITLE
docs: dispatch testing note (delegation to package:asobi)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ FlameGame
 
 See [`asobi-flame-demo`](https://github.com/widgrensit/asobi-flame-demo) for a complete arena shooter (boons, modifiers, voting) — uses `buildMatchInput` to emit the arena-shaped input.
 
+## Dispatch testing
+
+flame_asobi delegates all WebSocket dispatch to `package:asobi`. Protocol dispatch coverage lives there (see asobi-dart's `test/dispatch_test.dart`). flame_asobi's tests focus on the Flame component integration (`AsobiNetworkSync`, `AsobiPlayer`, `AsobiProjectile`, mixins) on top of those already-dispatched typed event streams.
+
 ## License
 
 Apache-2.0


### PR DESCRIPTION
## Summary

- flame_asobi is a thin Flame wrapper over `package:asobi` and maintains no event-name → callback mapping of its own
- All WebSocket protocol dispatch happens in asobi-dart; flame_asobi's components consume already-typed event streams (`onMatchState`, `onWorldTick`, `onMatchmakerMatched`, vote streams, etc.) and translate them into Flame components
- Adds a short `## Dispatch testing` section to the README pointing at asobi-dart's `test/dispatch_test.dart` so SDK consumers know where protocol coverage lives

## Investigation findings

Per the per-SDK protocol dispatch test rollout, I read all of `lib/`:

| File | Dispatch role |
| --- | --- |
| `flame_asobi.dart` | Re-exports `package:asobi` + the mixins |
| `has_asobi.dart` | Owns `AsobiClient`, no routing |
| `asobi_matchmaker.dart` | Subscribes to typed `onConnected` / `onMatchmakerMatched` / `onError` streams |
| `asobi_network_sync.dart` | Subscribes to typed `onMatchState` / `onMatchFinished` streams; translates `MatchState` → Flame components |
| `asobi_world_sync.dart` | Subscribes to typed `onWorldTick` stream; switches on `EntityDelta.op` (`a`/`u`/`r`) — entity delta op codes inside an already-dispatched payload, not protocol routing |
| `asobi_input_sender.dart` | Sends `match.input`, no routing |
| `asobi_vote_listener.dart` | Subscribes to typed vote streams |
| `asobi_player.dart` / `asobi_projectile.dart` | Apply `PlayerState` / `ProjectileState` to position components |

No event-name → callback maps. No re-firing of server messages as different events. Pure delegation, so no flame-specific dispatch test is warranted.

## Test plan

- [x] `lib/` reviewed; no protocol dispatch table found
- [x] Existing analyzer errors from `flame_asobi#11` left untouched per task constraints
- [x] No CI changes (docs-only)